### PR TITLE
Fix multiply_add_modular dropping accumulator when crt_count == 1

### DIFF
--- a/src/arith.rs
+++ b/src/arith.rs
@@ -6,6 +6,10 @@ pub fn multiply_uint_mod(a: u64, b: u64, modulus: u64) -> u64 {
     (((a as u128) * (b as u128)) % (modulus as u128)) as u64
 }
 
+pub fn add_uint_mod(a: u64, b: u64, modulus: u64) -> u64 {
+    (((a as u128) + (b as u128)) % (modulus as u128)) as u64
+}
+
 pub const fn log2(a: u64) -> u64 {
     std::mem::size_of::<u64>() as u64 * 8 - a.leading_zeros() as u64 - 1
 }
@@ -27,7 +31,7 @@ pub fn multiply_modular(params: &Params, a: u64, b: u64, c: usize) -> u64 {
 
 pub fn multiply_add_modular(params: &Params, a: u64, b: u64, x: u64, c: usize) -> u64 {
     if params.crt_count == 1 {
-        return multiply_uint_mod(a, b, params.moduli[c]);
+        return add_uint_mod(multiply_uint_mod(a, b, params.moduli[c]), x, params.moduli[c]);
     }
     barrett_coeff_u64(params, a * b + x, c)
 }
@@ -528,5 +532,56 @@ mod test {
             let val = rng.gen();
             assert_eq!(barrett_raw_u64(val, cr1, modulus), val % modulus);
         }
+    }
+
+    #[test]
+    fn add_uint_mod_correct() {
+        assert_eq!(add_uint_mod(3, 4, 11), 7);
+        assert_eq!(add_uint_mod(8, 5, 11), 2);
+        assert_eq!(add_uint_mod(0, 0, 11), 0);
+        assert_eq!(add_uint_mod(10, 10, 11), 9);
+        let large_mod = 180143985094819841u64;
+        assert_eq!(
+            add_uint_mod(large_mod - 1, 1, large_mod),
+            0
+        );
+        assert_eq!(
+            add_uint_mod(large_mod - 1, large_mod - 1, large_mod),
+            large_mod - 2
+        );
+    }
+
+    #[test]
+    fn multiply_add_modular_single_crt_includes_accumulator() {
+        let params = Params::init(
+            2048,
+            &vec![180143985094819841u64],
+            6.4,
+            2,
+            256,
+            20,
+            4,
+            8,
+            56,
+            8,
+            true,
+            9,
+            6,
+            1,
+            2048,
+            0,
+        );
+        assert_eq!(params.crt_count, 1);
+        let modulus = params.moduli[0];
+
+        assert_eq!(multiply_add_modular(&params, 3, 5, 7, 0), 22);
+        assert_eq!(multiply_add_modular(&params, 0, 5, 7, 0), 7);
+        assert_eq!(multiply_add_modular(&params, 3, 5, 0, 0), 15);
+
+        let a = modulus - 1;
+        let b = modulus - 1;
+        let x = modulus - 1;
+        let expected = ((((a as u128) * (b as u128)) + (x as u128)) % (modulus as u128)) as u64;
+        assert_eq!(multiply_add_modular(&params, a, b, x, 0), expected);
     }
 }

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -1042,6 +1042,82 @@ mod test {
     }
 
     #[test]
+    fn alt_full_multiply_correctness_larger_dimensions() {
+        let params = get_alt_params();
+        let mut m1 = PolyMatrixRaw::zero(&params, 1, 2);
+        let mut m2 = PolyMatrixRaw::zero(&params, 2, 1);
+        m1.get_poly_mut(0, 0)[0] = 2;
+        m1.get_poly_mut(0, 1)[0] = 3;
+        m2.get_poly_mut(0, 0)[0] = 5;
+        m2.get_poly_mut(1, 0)[0] = 7;
+        let m1_ntt = to_ntt_alloc(&m1);
+        let m2_ntt = to_ntt_alloc(&m2);
+        let m3_ntt = &m1_ntt * &m2_ntt;
+        let m3 = from_ntt_alloc(&m3_ntt);
+        assert_eq!(m3.get_poly(0, 0)[0], 31);
+    }
+
+    #[test]
+    fn full_multiply_correctness_larger_dimensions() {
+        let params = get_params();
+        let mut m1 = PolyMatrixRaw::zero(&params, 1, 2);
+        let mut m2 = PolyMatrixRaw::zero(&params, 2, 1);
+        m1.get_poly_mut(0, 0)[0] = 2;
+        m1.get_poly_mut(0, 1)[0] = 3;
+        m2.get_poly_mut(0, 0)[0] = 5;
+        m2.get_poly_mut(1, 0)[0] = 7;
+        let m1_ntt = to_ntt_alloc(&m1);
+        let m2_ntt = to_ntt_alloc(&m2);
+        let m3_ntt = &m1_ntt * &m2_ntt;
+        let m3 = from_ntt_alloc(&m3_ntt);
+        assert_eq!(m3.get_poly(0, 0)[0], 31);
+    }
+
+    #[test]
+    fn alt_full_multiply_correctness_2x2() {
+        let params = get_alt_params();
+        // | 1 2 |   | 5 6 |   | 1*5+2*7  1*6+2*8 |   | 19 22 |
+        // | 3 4 | * | 7 8 | = | 3*5+4*7  3*6+4*8 | = | 43 50 |
+        let mut m1 = PolyMatrixRaw::zero(&params, 2, 2);
+        let mut m2 = PolyMatrixRaw::zero(&params, 2, 2);
+        m1.get_poly_mut(0, 0)[0] = 1;
+        m1.get_poly_mut(0, 1)[0] = 2;
+        m1.get_poly_mut(1, 0)[0] = 3;
+        m1.get_poly_mut(1, 1)[0] = 4;
+        m2.get_poly_mut(0, 0)[0] = 5;
+        m2.get_poly_mut(0, 1)[0] = 6;
+        m2.get_poly_mut(1, 0)[0] = 7;
+        m2.get_poly_mut(1, 1)[0] = 8;
+        let m1_ntt = to_ntt_alloc(&m1);
+        let m2_ntt = to_ntt_alloc(&m2);
+        let m3_ntt = &m1_ntt * &m2_ntt;
+        let m3 = from_ntt_alloc(&m3_ntt);
+        assert_eq!(m3.get_poly(0, 0)[0], 19);
+        assert_eq!(m3.get_poly(0, 1)[0], 22);
+        assert_eq!(m3.get_poly(1, 0)[0], 43);
+        assert_eq!(m3.get_poly(1, 1)[0], 50);
+    }
+
+    #[test]
+    fn alt_full_multiply_correctness_inner_dim_3() {
+        let params = get_alt_params();
+        let mut m1 = PolyMatrixRaw::zero(&params, 1, 3);
+        let mut m2 = PolyMatrixRaw::zero(&params, 3, 1);
+        m1.get_poly_mut(0, 0)[0] = 10;
+        m1.get_poly_mut(0, 1)[0] = 20;
+        m1.get_poly_mut(0, 2)[0] = 30;
+        m2.get_poly_mut(0, 0)[0] = 1;
+        m2.get_poly_mut(1, 0)[0] = 2;
+        m2.get_poly_mut(2, 0)[0] = 3;
+        let m1_ntt = to_ntt_alloc(&m1);
+        let m2_ntt = to_ntt_alloc(&m2);
+        let m3_ntt = &m1_ntt * &m2_ntt;
+        let m3 = from_ntt_alloc(&m3_ntt);
+        // 10*1 + 20*2 + 30*3 = 10 + 40 + 90 = 140
+        assert_eq!(m3.get_poly(0, 0)[0], 140);
+    }
+
+    #[test]
     fn to_vec_correctness() {
         let params = get_params();
         let mut m1 = PolyMatrixRaw::zero(&params, 1, 1);


### PR DESCRIPTION
Discovered during the security audit of the codebase by Zellic.

## Summary

- **Fix**: `multiply_add_modular` in `arith.rs` ignored the accumulator `x` when `crt_count == 1`, returning `multiply_uint_mod(a, b, moduli[c])` instead of `(a*b + x) mod moduli[c]`. This caused incorrect results for polynomial matrix multiplication with inner dimension > 1 under single-CRT parameters.
- **Root cause**: The `crt_count == 1` branch was added to avoid `u64` overflow (since a single CRT modulus can be ~57 bits, making `a * b` exceed 64 bits), but the accumulator addition was accidentally omitted.
- **Fix approach**: Added `add_uint_mod` (using `u128` to prevent overflow of `a + b`) and used it to properly include the accumulator: `add_uint_mod(multiply_uint_mod(a, b, moduli[c]), x, moduli[c])`.

## Reproduction

The following test fails before the fix (returns 21 instead of 31) and passes after:

```rust
#[test]
fn alt_full_multiply_correctness_larger_dimensions() {
    let params = get_alt_params(); // crt_count == 1
    let mut m1 = PolyMatrixRaw::zero(&params, 1, 2);
    let mut m2 = PolyMatrixRaw::zero(&params, 2, 1);
    m1.get_poly_mut(0, 0)[0] = 2;
    m1.get_poly_mut(0, 1)[0] = 3;
    m2.get_poly_mut(0, 0)[0] = 5;
    m2.get_poly_mut(1, 0)[0] = 7;
    let m1_ntt = to_ntt_alloc(&m1);
    let m2_ntt = to_ntt_alloc(&m2);
    let m3_ntt = &m1_ntt * &m2_ntt;
    let m3 = from_ntt_alloc(&m3_ntt);
    // Expected: 2*5 + 3*7 = 31
    assert_eq!(m3.get_poly(0, 0)[0], 31);
}
```

The existing `alt_full_multiply_correctness` test uses 1x1 matrices, so no accumulation occurs and the bug is not triggered.

## Tests added

**Unit-level** (`arith.rs`):
- `add_uint_mod_correct` — basic correctness and modular wraparound
- `multiply_add_modular_single_crt_includes_accumulator` — directly verifies the accumulator is not dropped, including near-modulus edge cases

**Integration-level** (`poly.rs`):
- `alt_full_multiply_correctness_larger_dimensions` — `[2, 3] * [5; 7] = [31]` (inner dim 2, crt_count=1)
- `full_multiply_correctness_larger_dimensions` — same with default 2-CRT params (sanity)
- `alt_full_multiply_correctness_2x2` — full 2x2 matrix multiply (crt_count=1)
- `alt_full_multiply_correctness_inner_dim_3` — inner dimension 3 (crt_count=1)

All 37 tests pass (`cargo test`).